### PR TITLE
Minor changes

### DIFF
--- a/hugsql-core/src/hugsql/parameters.clj
+++ b/hugsql-core/src/hugsql/parameters.clj
@@ -90,6 +90,3 @@
 (defmethod apply-hugsql-param :i* [param data options] (identifier-param-list param data options))
 (defmethod apply-hugsql-param :identifier* [param data options] (identifier-param-list param data options))
 (defmethod apply-hugsql-param :sql [param data options] (sql-param param data options))
-
-
-

--- a/hugsql-core/src/hugsql/parser.clj
+++ b/hugsql-core/src/hugsql/parser.clj
@@ -4,7 +4,7 @@
 
 
 (defn- parse-error
-  ([rdr msg] 
+  ([rdr msg]
    (parse-error rdr msg {}))
   ([rdr msg data]
    (if (r/indexing-reader? rdr)
@@ -25,7 +25,7 @@
   (when c
     (Character/isWhitespace ^Character c)))
 
-(defn- symbol-char? 
+(defn- symbol-char?
   [c]
   (boolean (re-matches #"[\pL\pM\pS\d\_\-\.\+\*\?\:]" (str c))))
 
@@ -208,11 +208,11 @@
 
             ;; end of string, so return all, filtering out empty
             (nil? c)
-            (vec (remove #(and (empty? (:hdr %)) (empty? (:sql %)))
+            (vec (filter #(or (seq (:hdr %)) (seq (:sql %)))
                    (conj all
                      {:hdr hdr
-                      :sql (vec (remove empty? (conj sql (string/trimr (str sb)))))})))
-            
+                      :sql (vec (filter seq (conj sql (string/trimr (str sb)))))})))
+
             ;; SQL comments and hugsql header comments
             (or
               (sing-line-comment-start? c rdr)
@@ -223,13 +223,13 @@
               ;; if sql is active, then new section
               (if (or (> (.length sb) 0) (empty? hdr))
                 (recur h [] (nsb)
-                  (conj all {:hdr hdr :sql (vec (remove empty? (conj sql (string/trimr (str sb)))))}))
+                  (conj all {:hdr hdr :sql (vec (filter seq (conj sql (string/trimr (str sb)))))}))
                 (recur (merge hdr h) sql sb all))
-              (recur hdr sql sb all))            
-            
+              (recur hdr sql sb all))
+
 
             ;; quoted SQL (which cannot contain hugsql params,
-            ;; so we consider them separately here before 
+            ;; so we consider them separately here before
             (sql-quoted-start? c)
             (recur hdr sql (sb-append sb (read-sql-quoted rdr c)) all)
 
@@ -244,7 +244,7 @@
             ;; hugsql params
             (hugsql-param-start? c)
             (recur hdr
-              (vec (remove empty?
+              (vec (filter seq
                      (conj sql (str sb) (read-hugsql-param rdr c))))
               (nsb)
               all)

--- a/hugsql-core/test/hugsql/core_test.clj
+++ b/hugsql-core/test/hugsql/core_test.clj
@@ -18,7 +18,7 @@
                  :subname "//127.0.0.1:5432/hugtest"
                  :user "hugtest"
                  :password "hugtest"}
-   
+
 
    ;; mysql -u root -p
    ;; mysql> create database hugtest;
@@ -29,8 +29,8 @@
             :password "hugtest"}
 
    :sqlite {:subprotocol "sqlite"
-            :subname (str tmpdir "/hugtest.sqlite")}                          
-   
+            :subname (str tmpdir "/hugtest.sqlite")}
+
    :h2 {:subprotocol "h2"
         :subname (str tmpdir "/hugtest.h2")}
 
@@ -49,7 +49,7 @@
 
     (doseq [adapter adapters]
       (hugsql/set-adapter! adapter)
-      
+
       (testing "fn definition"
         (is (fn? no-params-select))
         (is (fn? no-params-select-sqlvec))
@@ -98,7 +98,7 @@
                 {:columns ["test.id", "test.name"]}
                 {:quoting :mssql}))))
 
-      
+
 
       (testing "database commands/queries"
         (is (= 0 (create-test-table db)))


### PR DESCRIPTION
Removed trailing whitespace.
*adapter* didn't have to be dynamic, or wrapped in an atom.
renamed *adapter* to adapter, to be in line with conventions.
(remove empty? []) => (filter (complement #(not (seq %))) []) => (filter seq [])

Should also make code faster, but probably not noticeable. All tests pass.