### PR TITLE
Upgrade to latest clojure.jdbc

### DIFF
--- a/hugsql-adapter-clojure-jdbc/project.clj
+++ b/hugsql-adapter-clojure-jdbc/project.clj
@@ -1,9 +1,9 @@
-(defproject com.layerware/hugsql-adapter-clojure-jdbc "0.4.7"
+(defproject com.layerware/hugsql-adapter-clojure-jdbc "0.4.8-SNAPSHOT"
   :description "clojure.jdbc hugsql adapter"
   :url "https://github.com/layerware/hugsql"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :scm {:dir ".."}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.layerware/hugsql-adapter "0.4.7"]
-                 [funcool/clojure.jdbc "0.7.0"]])
+                 [funcool/clojure.jdbc "0.9.0"]])


### PR DESCRIPTION
The latest clojure.jdbc supports ```.getGeneratedKeys```

To get the returned keys, pass ```{:returning true}``` as command options to the query.