### PR TITLE
Specify transform function to be applied to results

### DIFF
--- a/hugsql-core/test/hugsql/parser_test.clj
+++ b/hugsql-core/test/hugsql/parser_test.clj
@@ -72,7 +72,13 @@
                      :file nil
                      :line 1}
                :sql ["select * from emp"]}]
-             (parse "-- :name test\nselect * from emp"))))
+             (parse "-- :name test\nselect * from emp")))
+      (is (= [{:hdr {:name ["test"]
+                     :file nil
+                     :line 1
+                     :transform ["hugsql.transform/test"]}
+               :sql ["select * from emp"]}]
+             (parse "-- :name test\n-- :transform hugsql.transform/test\nselect * from emp"))))
 
     (testing ":param-name (default value parameter type)"
       (is (= [{:hdr {:name ["test"]


### PR DESCRIPTION
Added ability to specify a transformation function within HugSQL SQL file which will be applied to the results of the query.  Here is an example usage:

```clojure
;; Define the transformation function
(ns myapp.transform
  (:require [camel-snake-kebab.core :refer [->kebab-case-keyword]]
            [camel-snake-kebab.extras :refer [transform-keys]]))

(def kebab-keys (partial transform-keys ->kebab-case-keyword))
```
Define the SQL query where the transformation function is used

```sql
-- :name select-concept-by-id
-- :command :query
-- :result :one
-- :transform myapp.transform/kebab-keys
-- :doc SELECT statement to pull a single concept based on ID
SELECT c.id, c.client_id, c.client_name
FROM menu.concepts c
WHERE c.id = :id;
```

Load the SQL functions into a Clojure Namespace.  Note that the `myapp.transform` namespace is `:require`d so that the transform function is in scope.  I don't love this, though it is a relatively small cost.  Might be able to improve the experience here by auto-loading the namespace of fully qualified transform functions.

```clojure
(ns myapp.queries
  (:require [myapp.transform]  ;; necessary to bring transform function into scope.  
            [hugsql.core :as hugsql]))

(hugsql/def-db-fns "queries.sql")
```

Use the function, noting that the `client_id` and `client_name` fields are returned as `kebab-case` keywords instead of `snake_case` as they come out of the DB:

```clojure
user> (require '[myapp.queries :as q])
user> (require '[myapp.db :refer [db]])
user> (q/select-concept-by-id db {:id 1})
;; => {:id 1, :client-id 123456, :client-name "Acme"}
```

If the `result` is `:one` or `:1`, the transformation function will be applied directly to the result.  If the `result` is `:many` or `:*`, the transformation function will be applied to each item in the result sequence via `map`.  All other result types ignore the transformation function and return the result untouched.

This is a feature that Korma SQL supported.  Since switching to HugSQL, it is highly unlikely I will return to using Korma.  However, I did find this particular feature very useful as it significantly reduced the amount of copy/pasted code to convert keys and generally helped keep the code base clean.