### PR TITLE
Issue #112: Add two test hugsql functions which include usages of Postgres types.

### DIFF
--- a/hugsql-core/test/hugsql/core_test.clj
+++ b/hugsql-core/test/hugsql/core_test.clj
@@ -117,10 +117,14 @@
     (is (= ["select * from test"] (no-params-select-sqlvec {})))
     (is (= ["select * from test where id = ?" 1]
            (one-value-param-sqlvec {:id 1})))
+    (is (= ["select * from test where id = ?::int" "1"]
+           (one-typed-value-param-sqlvec {:id "1"})))
     (is (= ["select * from test\nwhere id = ?\nand name = ?" 1 "Ed"]
            (multi-value-params-sqlvec {:id 1 :name "Ed"})))
     (is (= ["select * from test\nwhere id in (?,?,?)" 1 2 3]
            (value-list-param-sqlvec {:ids [1,2,3]})))
+    (is (= ["select * from test\nwhere id in (?,?,?::int)" "1" "2" "3"] ;; Notice only the last entry receives the pg-type
+           (typed-value-list-param-sqlvec {:ids ["1","2","3"]})))
     (is (= ["select * from test\nwhere (id, name) = (?,?)" 1 "A"]
            (tuple-param-sqlvec {:id-name [1 "A"]})))
     (is (= ["insert into test (id, name)\nvalues (?,?),(?,?),(?,?)" 1 "Ed" 2 "Al" 3 "Bo"]

--- a/hugsql-core/test/hugsql/sql/test.sql
+++ b/hugsql-core/test/hugsql/sql/test.sql
@@ -13,6 +13,10 @@ select * from test
 -- :doc One value param
 select * from test where id = :id
 
+-- :name one-typed-value-param
+-- :doc One typed value param
+select * from test where id = :id::int
+
 -- :name multi-value-params
 -- :doc Multi value params
 select * from test
@@ -23,6 +27,11 @@ and name = :name
 -- :doc Value List Param
 select * from test
 where id in (:v*:ids)
+
+-- :name typed-value-list-param
+-- :doc Value List of Typed Param
+select * from test
+where id in (:v*:ids::int)
 
 -- :name tuple-param
 -- :doc Tuple Param


### PR DESCRIPTION
Ideally the hugsql function
```sql
-- :name typed-value-list-param
-- :doc Value List of Typed Param
select * from test
where id in (:v*:ids::int)
```
should satisfy the predicate
```clojure 
(= ["select * from test\nwhere id in (?::int,?::int,?::int)" "1" "2" "3"]
   (typed-value-list-param-sqlvec {:ids ["1","2","3"]})))
``` 
However, given that Postgres types are not tokenized by the compiler (and presumably there is no desire to do so) I think it's acceptable to communicate that the syntax `(:v*:ids::int)` is not accepted. Ideally this can find its way into a warning somewhere in the docs at https://www.hugsql.org/.