### PR TITLE
Avoid calling apply in hugsql.adapter.clojure-java-jdbc

### DIFF
--- a/hugsql-adapter-clojure-java-jdbc/src/hugsql/adapter/clojure_java_jdbc.clj
+++ b/hugsql-adapter-clojure-java-jdbc/src/hugsql/adapter/clojure_java_jdbc.clj
@@ -12,7 +12,7 @@
       (apply jdbc/execute! db sqlvec (:command-options options))))
 
   (query [this db sqlvec options]
-    (apply jdbc/query db sqlvec (:command-options options)))
+    (jdbc/query db sqlvec (:command-options options)))
 
   (result-one [this result options]
     (first result))


### PR DESCRIPTION
This patch fixes a mismatch where the adapter was wrong splicing parameters instead of passing
`:command-options` directly to `jdbc/query`.