### PR TITLE
Minor name change

### DIFF
--- a/docs/hugsql.org/index.html
+++ b/docs/hugsql.org/index.html
@@ -295,7 +295,7 @@ Macro
       <ul>
         <li><code>db</code> is a db-spec, a connection, a connection
         pool, or a transaction object</li>
-        <li><code>param-data</code> is a hashmap of parameter data
+        <li><code>params</code> is a hashmap of parameter data
         where the keys match parameter placeholder names in your
           SQL</li>
         <li><code>options</code> is a hashmap of HugSQL-specific


### PR DESCRIPTION
The example and the following documentation are using a slightly different variable name. This syncs them up.