### PR TITLE
upgrade org.clojure/java.jdbc to "0.7.12"

### DIFF
--- a/hugsql-adapter-clojure-java-jdbc/project.clj
+++ b/hugsql-adapter-clojure-java-jdbc/project.clj
@@ -5,5 +5,5 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :scm {:dir ".."}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/java.jdbc "0.7.10"]
+                 [org.clojure/java.jdbc "0.7.12"]
                  [com.layerware/hugsql-adapter "0.5.1"]])


### PR DESCRIPTION
The hugsql-adapter-clojure-java-jdbc depends on org.clojure/java.jdbc version 0.7.10. This version has a critical bug, in which it sometimes commits partial transactions even after a failure. See issue attached. This PR upgrades to 0.7.12, in which this bug is no longer present.

https://clojure.atlassian.net/browse/JDBC-179