### PR TITLE
Make % an allowed keyword character

### DIFF
--- a/hugsql-core/src/hugsql/parser.clj
+++ b/hugsql-core/src/hugsql/parser.clj
@@ -26,7 +26,7 @@
 
 (defn- symbol-char?
   [c]
-  (boolean (re-matches #"[\pL\pM\pS\d\_\-\.\+\*\?\:\/]" (str c))))
+  (boolean (re-matches #"[\pL\pM\pS\d\_\-\.\+\*\?\:\/%]" (str c))))
 
 (defn- skip-ws-to-next-line
   "Read from reader until a non-whitespace or newline char is encountered."


### PR DESCRIPTION
I encountered a database column with a percentage sign in its name. When trying to list it using a
generic sql function that inserts a row with column names based on the keys given in a map, I found
that HugSQL would lex `:portion_%` into `:portion_` and then error out telling the user:

Parameter Mismatch: :portion_ parameter data not found.

This commit expands the characters allowed in keywords to include the percentage sign %.