### PR TITLE
correct require

### DIFF
--- a/docs/hugsql.org/docs/hugsql-adapters/setting-an-adapter.md
+++ b/docs/hugsql.org/docs/hugsql-adapters/setting-an-adapter.md
@@ -12,7 +12,7 @@ Within your Clojure code, you will need to explicitly set the adapter. You can d
 (ns my-app
   (:require [hugsql.core :as hugsql]
             [hugsql.adapter.next-jdbc :as next-adapter
-            [next.jdbc.result-set :as rs]]]))
+            [next.jdbc.result-set :as result-set]]]))
 
 (defn app-init []
   (hugsql/set-adapter! (next-adapter/hugsql-adapter-next-jdbc)))


### PR DESCRIPTION
`next.jdbc.result-set` is required as `rs` in the docs, but referred to as `result-set` in its usage.